### PR TITLE
feat: RSS-ECOMM-2_16 Add a button on the registration page that allows users to navigate to the login page

### DIFF
--- a/src/components/formComponents/ButtonToAnotherPage.tsx
+++ b/src/components/formComponents/ButtonToAnotherPage.tsx
@@ -1,0 +1,26 @@
+import { Link as LinkRouter } from 'react-router-dom';
+
+import { Link, Stack, Typography } from '@mui/material';
+
+type ButtonToAnotherPageProps = {
+  addressPage: string;
+  textOnButton: string;
+  title: string;
+};
+
+function ButtonToAnotherPage({
+  title,
+  textOnButton,
+  addressPage,
+}: ButtonToAnotherPageProps): JSX.Element {
+  return (
+    <Stack direction="row" spacing={1} sx={{ typography: 'body1' }}>
+      <Typography>{title}</Typography>
+      <Link component={LinkRouter} to={addressPage}>
+        {textOnButton}
+      </Link>
+    </Stack>
+  );
+}
+
+export default ButtonToAnotherPage;

--- a/src/features/registrationPage/registrationForm/RegistrationForm.tsx
+++ b/src/features/registrationPage/registrationForm/RegistrationForm.tsx
@@ -11,6 +11,7 @@ import Typography from '@mui/material/Typography';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 import { createCustomer } from '@/api/clientService';
+import ButtonToAnotherPage from '@/components/formComponents/ButtonToAnotherPage';
 import { FormInputText } from '@/components/formComponents/FormInputText';
 import FormSelect from '@/components/formComponents/FormSelect';
 import RulesValidation from '@/components/formComponents/rulesValidation';
@@ -65,6 +66,11 @@ export default function FormOfRegistration({ resultOfSubmit }: Props): JSX.Eleme
           <Typography component="h1" variant="h5">
             Registration
           </Typography>
+          <ButtonToAnotherPage
+            addressPage="/login"
+            textOnButton="Sign in"
+            title="Already have an account?"
+          />
           <Box
             component="form"
             noValidate


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [x] Feature
- [ ] Bug Fix
- [ ] Breaking Change
- [ ] Code Refactor
- [ ] Documentation Update

## Description
- add a button component to go to another page
- add a button component to the registration form

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- [RSS-ECOMM-2_16](https://funcode.youtrack.cloud/issue/FP-57/RSS-ECOMM-216-Add-a-button-or-link-on-the-registration-page-that-allows-users-to-navigate-to-the-login-page)

## Screenshots, Recordings

![image](https://github.com/skayer81/eCommerce-Application/assets/114329023/395bf013-058e-4693-b407-97a185792fc2)
